### PR TITLE
Initialize buffer to all zeros rather than only setting the capacity

### DIFF
--- a/backend/canisters/bucket/impl/src/model/blobs.rs
+++ b/backend/canisters/bucket/impl/src/model/blobs.rs
@@ -350,7 +350,7 @@ impl From<PutChunkArgs> for PendingBlob {
             chunk_size: args.chunk_size,
             total_size: args.total_size,
             remaining_chunks: (0..chunk_count).into_iter().collect(),
-            bytes: ByteBuf::with_capacity(args.total_size as usize),
+            bytes: ByteBuf::from(vec![0; args.total_size as usize]),
         };
         pending_blob.add_chunk(args.chunk_index, args.bytes);
         pending_blob


### PR DESCRIPTION
Without this we get an index out of bounds error since although the Vec has the correct capacity, it still has length 0.