### PR TITLE
Remove deserialization attributes from shared types

### DIFF
--- a/backend/libraries/types/src/file.rs
+++ b/backend/libraries/types/src/file.rs
@@ -4,28 +4,22 @@ use serde::{Deserialize, Serialize};
 
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub struct FileAdded {
-    #[serde(rename(deserialize = "blob_id"))]
     pub file_id: FileId,
     pub uploaded_by: UserId,
-    #[serde(rename(deserialize = "blob_hash"))]
     pub hash: Hash,
-    #[serde(rename(deserialize = "blob_size"))]
     pub size: u64,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub struct FileRemoved {
-    #[serde(default)]
     pub file_id: FileId,
     pub uploaded_by: UserId,
-    #[serde(rename(deserialize = "blob_hash"))]
     pub hash: Hash,
     pub blob_deleted: bool,
 }
 
 #[derive(CandidType, Deserialize, Debug)]
 pub struct FileRejected {
-    #[serde(rename(deserialize = "blob_id"))]
     pub file_id: FileId,
     pub reason: FileRejectedReason,
 }


### PR DESCRIPTION
This is needed to upgrade the index canister.

Without this, when the bucket canisters send these objects to the index, the attributes make the index look for the old field names.

So we need to upgrade the buckets with these attributes, then remove them, then upgrade the index.