### PR TITLE
Rename 'uploaded_by' to 'owner'

### DIFF
--- a/backend/canisters/bucket/impl/src/lifecycle/heartbeat.rs
+++ b/backend/canisters/bucket/impl/src/lifecycle/heartbeat.rs
@@ -47,7 +47,7 @@ mod sync_index {
             let file_id = file.file_id;
             let reason = file.reason.into();
 
-            if let Some(user_id) = runtime_state.data.files.uploaded_by(&file.file_id) {
+            if let Some(user_id) = runtime_state.data.files.owner(&file.file_id) {
                 if let Some(user) = runtime_state.data.users.get_mut(&user_id) {
                     let old_status = user.set_file_status(file_id, FileStatusInternal::Rejected(reason));
 

--- a/backend/canisters/bucket/impl/src/updates/upload_chunk.rs
+++ b/backend/canisters/bucket/impl/src/updates/upload_chunk.rs
@@ -75,7 +75,7 @@ fn upload_chunk_impl(args: Args, runtime_state: &mut RuntimeState) -> Response {
                     .index_sync_state
                     .enqueue(EventToSync::FileRemoved(FileRemoved {
                         file_id,
-                        uploaded_by: user_id,
+                        owner: user_id,
                         hash: hm.provided_hash,
                         blob_deleted: !runtime_state.data.files.contains_hash(&hm.provided_hash),
                     }));

--- a/backend/canisters/index/impl/src/queries/allocated_bucket.rs
+++ b/backend/canisters/index/impl/src/queries/allocated_bucket.rs
@@ -21,7 +21,7 @@ fn allocated_bucket_impl(args: Args, runtime_state: &RuntimeState) -> Response {
     if let Some(user) = runtime_state.data.users.get(&user_id) {
         let byte_limit = user.byte_limit;
         let bytes_used = user.bytes_used;
-        let bytes_used_after_upload = if runtime_state.data.blobs.has_user_uploaded_blob(&user_id, &args.file_hash) {
+        let bytes_used_after_upload = if runtime_state.data.blobs.user_owns_blob(&user_id, &args.file_hash) {
             bytes_used
         } else {
             bytes_used

--- a/backend/libraries/types/src/file.rs
+++ b/backend/libraries/types/src/file.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub struct FileAdded {
     pub file_id: FileId,
-    pub uploaded_by: UserId,
+    #[serde(rename(deserialize = "uploaded_by"))]
+    pub owner: UserId,
     pub hash: Hash,
     pub size: u64,
 }
@@ -13,7 +14,8 @@ pub struct FileAdded {
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub struct FileRemoved {
     pub file_id: FileId,
-    pub uploaded_by: UserId,
+    #[serde(rename(deserialize = "uploaded_by"))]
+    pub owner: UserId,
     pub hash: Hash,
     pub blob_deleted: bool,
 }


### PR DESCRIPTION
'uploaded_by' doesn't make sense once we implement the ability to forward files, whereas 'owner' works in all cases.