### PR TITLE
Remove serde attributes from shared types

### DIFF
--- a/backend/libraries/types/src/file.rs
+++ b/backend/libraries/types/src/file.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub struct FileAdded {
     pub file_id: FileId,
-    #[serde(rename(deserialize = "uploaded_by"))]
     pub owner: UserId,
     pub hash: Hash,
     pub size: u64,
@@ -14,7 +13,6 @@ pub struct FileAdded {
 #[derive(CandidType, Serialize, Deserialize, Debug)]
 pub struct FileRemoved {
     pub file_id: FileId,
-    #[serde(rename(deserialize = "uploaded_by"))]
     pub owner: UserId,
     pub hash: Hash,
     pub blob_deleted: bool,


### PR DESCRIPTION
These need to be removed before upgrading the index canister