### PR TITLE
Store blob data in stable memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "http_request",
  "ic-cdk",
  "ic-cdk-macros",
+ "ic-stable-structures",
  "index_canister",
  "index_canister_c2c_client",
  "num-traits",
@@ -993,6 +994,11 @@ dependencies = [
  "serde_tokenstream",
  "syn",
 ]
+
+[[package]]
+name = "ic-stable-structures"
+version = "0.1.2"
+source = "git+https://github.com/dfinity/stable-structures?rev=ed68e459193a83a02f6914b011f4354d513cb6cd#ed68e459193a83a02f6914b011f4354d513cb6cd"
 
 [[package]]
 name = "ic-utils"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,7 +998,8 @@ dependencies = [
 [[package]]
 name = "ic-stable-structures"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/stable-structures#ed68e459193a83a02f6914b011f4354d513cb6cd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8ded18fe296ff693ba8d8fd9890189ea28df4fc75d8b009523e15918452d8b"
 
 [[package]]
 name = "ic-utils"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,7 +998,7 @@ dependencies = [
 [[package]]
 name = "ic-stable-structures"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/stable-structures?rev=ed68e459193a83a02f6914b011f4354d513cb6cd#ed68e459193a83a02f6914b011f4354d513cb6cd"
+source = "git+https://github.com/dfinity/stable-structures#ed68e459193a83a02f6914b011f4354d513cb6cd"
 
 [[package]]
 name = "ic-utils"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ hex = "0.4.3"
 ic-agent = "0.22.0"
 ic-cdk = "0.6.1"
 ic-cdk-macros = "0.6.1"
-ic-stable-structures = { git = "https://github.com/dfinity/stable-structures", version = "0.1.2" }
+ic-stable-structures = "0.1.2"
 ic-utils = "0.22.0"
 itertools = "0.10.5"
 num-traits = "0.2.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ hex = "0.4.3"
 ic-agent = "0.22.0"
 ic-cdk = "0.6.1"
 ic-cdk-macros = "0.6.1"
+ic-stable-structures = { git = "https://github.com/dfinity/stable-structures", rev = "ed68e459193a83a02f6914b011f4354d513cb6cd" }
 ic-utils = "0.22.0"
 itertools = "0.10.5"
 num-traits = "0.2.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ hex = "0.4.3"
 ic-agent = "0.22.0"
 ic-cdk = "0.6.1"
 ic-cdk-macros = "0.6.1"
-ic-stable-structures = { git = "https://github.com/dfinity/stable-structures", rev = "ed68e459193a83a02f6914b011f4354d513cb6cd" }
+ic-stable-structures = { git = "https://github.com/dfinity/stable-structures", version = "0.1.2" }
 ic-utils = "0.22.0"
 itertools = "0.10.5"
 num-traits = "0.2.15"

--- a/backend/canisters/bucket/impl/Cargo.toml
+++ b/backend/canisters/bucket/impl/Cargo.toml
@@ -18,6 +18,7 @@ canister_state_macros = { workspace = true }
 http_request = { path = "../../../libraries/http_request" }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
+ic-stable-structures = { workspace = true }
 index_canister = { path = "../../index/api" }
 index_canister_c2c_client = { path = "../../index/c2c_client" }
 num-traits = { workspace = true }

--- a/backend/canisters/bucket/impl/src/lib.rs
+++ b/backend/canisters/bucket/impl/src/lib.rs
@@ -8,10 +8,10 @@ use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use types::{CanisterId, Cycles, FileId, TimestampMillis, Timestamped, Version};
 use utils::env::Environment;
-use utils::memory;
 
 mod guards;
 mod lifecycle;
+mod memory;
 mod model;
 mod queries;
 mod updates;
@@ -71,7 +71,7 @@ impl RuntimeState {
         let file_metrics = self.data.files.metrics();
 
         Metrics {
-            memory_used: memory::used(),
+            memory_used: utils::memory::used(),
             now: self.env.now(),
             cycles_balance: self.env.cycles_balance(),
             wasm_version: WASM_VERSION.with(|v| **v.borrow()),

--- a/backend/canisters/bucket/impl/src/lib.rs
+++ b/backend/canisters/bucket/impl/src/lib.rs
@@ -111,8 +111,8 @@ pub struct Metrics {
     pub now: TimestampMillis,
     pub cycles_balance: Cycles,
     pub wasm_version: Version,
-    pub file_count: u32,
-    pub blob_count: u32,
+    pub file_count: u64,
+    pub blob_count: u64,
     pub index_sync_queue_length: u32,
 }
 

--- a/backend/canisters/bucket/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/bucket/impl/src/lifecycle/post_upgrade.rs
@@ -16,8 +16,10 @@ fn post_upgrade(args: Args) {
     let env = Box::new(CanisterEnv::new());
     let reader = BufferedStableReader::new(BUFFER_SIZE);
 
-    let (data, log_messages, trace_messages): (Data, Vec<LogMessage>, Vec<LogMessage>) =
+    let (mut data, log_messages, trace_messages): (Data, Vec<LogMessage>, Vec<LogMessage>) =
         serializer::deserialize(reader).unwrap();
+
+    data.files.migrate_to_stable_storage();
 
     init_logger(data.test_mode);
     init_state(env, data, args.wasm_version);

--- a/backend/canisters/bucket/impl/src/lifecycle/pre_upgrade.rs
+++ b/backend/canisters/bucket/impl/src/lifecycle/pre_upgrade.rs
@@ -1,8 +1,9 @@
 use crate::lifecycle::BUFFER_SIZE;
+use crate::memory::get_upgrades_memory;
 use crate::{take_state, LOG_MESSAGES};
 use canister_api_macros::trace;
-use ic_cdk::api::stable::BufferedStableWriter;
 use ic_cdk_macros::pre_upgrade;
+use ic_stable_structures::writer::{BufferedWriter, Writer};
 use tracing::info;
 
 #[pre_upgrade]
@@ -17,6 +18,9 @@ fn pre_upgrade() {
     let trace_messages = messages_container.traces.drain_messages();
 
     let stable_state = (state.data, log_messages, trace_messages);
-    let writer = BufferedStableWriter::new(BUFFER_SIZE);
-    serializer::serialize(&stable_state, writer).unwrap();
+
+    let mut memory = get_upgrades_memory();
+    let writer = BufferedWriter::new(BUFFER_SIZE, Writer::new(&mut memory, 0));
+
+    serializer::serialize(stable_state, writer).unwrap();
 }

--- a/backend/canisters/bucket/impl/src/memory.rs
+++ b/backend/canisters/bucket/impl/src/memory.rs
@@ -1,0 +1,26 @@
+use ic_stable_structures::{
+    memory_manager::{MemoryId, MemoryManager, VirtualMemory},
+    DefaultMemoryImpl,
+};
+
+const UPGRADES: MemoryId = MemoryId::new(0);
+const BLOBS: MemoryId = MemoryId::new(1);
+
+pub type Memory = VirtualMemory<DefaultMemoryImpl>;
+
+thread_local! {
+    static MEMORY_MANAGER: MemoryManager<DefaultMemoryImpl>
+        = MemoryManager::init(DefaultMemoryImpl::default());
+}
+
+pub fn get_upgrades_memory() -> Memory {
+    get_memory(UPGRADES)
+}
+
+pub fn get_blobs_memory() -> Memory {
+    get_memory(BLOBS)
+}
+
+fn get_memory(id: MemoryId) -> Memory {
+    MEMORY_MANAGER.with(|m| m.get(id))
+}

--- a/backend/canisters/bucket/impl/src/model/files.rs
+++ b/backend/canisters/bucket/impl/src/model/files.rs
@@ -1,7 +1,8 @@
+use crate::model::stable_blob_storage::StableBlobStorage;
 use crate::{calc_chunk_count, MAX_BLOB_SIZE_BYTES};
 use bucket_canister::upload_chunk_v2::Args as UploadChunkArgs;
 use candid::Principal;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_bytes::ByteBuf;
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
@@ -15,8 +16,8 @@ pub struct Files {
     pending_files: HashMap<FileId, PendingFile>,
     reference_counts: ReferenceCounts,
     accessors_map: AccessorsMap,
-    // TODO move this to stable memory
-    blobs: HashMap<Hash, ByteBuf>,
+    #[serde(deserialize_with = "migrate_to_stable_storage")]
+    blobs: StableBlobStorage,
     bytes_used: u64,
 }
 
@@ -45,7 +46,7 @@ impl Files {
         self.pending_files.get(file_id)
     }
 
-    pub fn blob_bytes(&self, hash: &Hash) -> Option<&ByteBuf> {
+    pub fn blob_bytes(&self, hash: &Hash) -> Option<Vec<u8>> {
         self.blobs.get(hash)
     }
 
@@ -253,11 +254,11 @@ impl Files {
     }
 
     pub fn contains_hash(&self, hash: &Hash) -> bool {
-        self.blobs.contains_key(hash)
+        self.blobs.exists(hash)
     }
 
     pub fn data_size(&self, hash: &Hash) -> Option<u64> {
-        self.blobs.get(hash).map(|b| b.len() as u64)
+        self.blobs.data_size(hash)
     }
 
     pub fn bytes_used(&self) -> u64 {
@@ -266,8 +267,8 @@ impl Files {
 
     pub fn metrics(&self) -> Metrics {
         Metrics {
-            file_count: self.files.len() as u32,
-            blob_count: self.blobs.len() as u32,
+            file_count: self.files.len() as u64,
+            blob_count: self.blobs.len(),
         }
     }
 
@@ -276,7 +277,7 @@ impl Files {
             .link_many(completed_file.owner, completed_file.accessors.iter().copied(), file_id);
 
         self.reference_counts.incr(completed_file.hash);
-        self.add_blob_if_not_exists(completed_file.hash, completed_file.bytes);
+        self.add_blob_if_not_exists(completed_file.hash, completed_file.bytes.into_vec());
 
         self.files.insert(
             file_id,
@@ -290,23 +291,21 @@ impl Files {
         );
     }
 
-    fn add_blob_if_not_exists(&mut self, hash: Hash, bytes: ByteBuf) {
-        if let Vacant(e) = self.blobs.entry(hash) {
+    fn add_blob_if_not_exists(&mut self, hash: Hash, bytes: Vec<u8>) {
+        if !self.blobs.exists(&hash) {
             self.bytes_used = self
                 .bytes_used
                 .checked_add(bytes.len() as u64)
                 .expect("'bytes_used' overflowed");
 
-            e.insert(bytes);
+            self.blobs.insert(hash, bytes);
         }
     }
 
     fn remove_blob(&mut self, hash: &Hash) {
-        if let Some(bytes) = self.blobs.remove(hash) {
-            self.bytes_used = self
-                .bytes_used
-                .checked_sub(bytes.len() as u64)
-                .expect("'bytes used' underflowed");
+        if let Some(size) = self.blobs.data_size(hash) {
+            self.blobs.remove(hash);
+            self.bytes_used = self.bytes_used.checked_sub(size as u64).expect("'bytes used' underflowed");
         }
     }
 
@@ -533,6 +532,19 @@ pub struct ChunkSizeMismatch {
 }
 
 pub struct Metrics {
-    pub file_count: u32,
-    pub blob_count: u32,
+    pub file_count: u64,
+    pub blob_count: u64,
+}
+
+// One time job to move files into stable storage
+fn migrate_to_stable_storage<'de, D: Deserializer<'de>>(de: D) -> Result<StableBlobStorage, D::Error> {
+    let map: HashMap<Hash, ByteBuf> = HashMap::deserialize(de)?;
+
+    let mut storage = StableBlobStorage::default();
+
+    for (k, v) in map {
+        storage.insert(k, v.into_vec());
+    }
+
+    Ok(storage)
 }

--- a/backend/canisters/bucket/impl/src/model/mod.rs
+++ b/backend/canisters/bucket/impl/src/model/mod.rs
@@ -1,3 +1,4 @@
 pub mod files;
 pub mod index_sync_state;
+pub mod stable_blob_storage;
 pub mod users;

--- a/backend/canisters/bucket/impl/src/model/stable_blob_storage.rs
+++ b/backend/canisters/bucket/impl/src/model/stable_blob_storage.rs
@@ -1,13 +1,11 @@
-use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
-use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap, Storable};
+use crate::memory::{get_blobs_memory, Memory};
+use ic_stable_structures::{StableBTreeMap, Storable};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::mem::size_of;
 use types::Hash;
 
 const MAX_VALUE_SIZE: usize = 4 * 1024; // 4KB
-
-type Memory = VirtualMemory<DefaultMemoryImpl>;
 
 #[derive(Serialize, Deserialize)]
 pub struct StableBlobStorage {
@@ -17,7 +15,7 @@ pub struct StableBlobStorage {
 
 impl StableBlobStorage {
     pub fn get(&self, hash: &Hash) -> Option<Vec<u8>> {
-        self.value_iterator(hash).map(|i| i.flat_map(|v| v).collect())
+        self.value_iterator(hash).map(|i| i.flatten().collect())
     }
 
     pub fn data_size(&self, hash: &Hash) -> Option<u64> {
@@ -65,8 +63,7 @@ impl StableBlobStorage {
 }
 
 fn init_blobs() -> StableBTreeMap<Memory, Key, Vec<u8>> {
-    let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
-    let memory = memory_manager.get(MemoryId::new(0));
+    let memory = get_blobs_memory();
 
     StableBTreeMap::init(memory, size_of::<Key>() as u32, MAX_VALUE_SIZE as u32)
 }

--- a/backend/canisters/bucket/impl/src/model/stable_blob_storage.rs
+++ b/backend/canisters/bucket/impl/src/model/stable_blob_storage.rs
@@ -125,7 +125,7 @@ mod tests {
         assert_eq!(value_in, value_out)
     }
 
-    // Checks that, for keys with matching prefixes, KeyA > KeyB <=> chunk_index A > chunk_index B
+    // Checks that for keys with matching prefixes, KeyA > KeyB <=> chunk_index A > chunk_index B
     #[test]
     fn key_ordering() {
         let hash = default_hash();

--- a/backend/canisters/bucket/impl/src/model/stable_blob_storage.rs
+++ b/backend/canisters/bucket/impl/src/model/stable_blob_storage.rs
@@ -1,0 +1,147 @@
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap, Storable};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::mem::size_of;
+use types::Hash;
+
+const MAX_VALUE_SIZE: usize = 4 * 1024; // 4KB
+
+type Memory = VirtualMemory<DefaultMemoryImpl>;
+
+#[derive(Serialize, Deserialize)]
+pub struct StableBlobStorage {
+    #[serde(skip, default = "init_blobs")]
+    blobs: StableBTreeMap<Memory, Key, Vec<u8>>,
+}
+
+impl StableBlobStorage {
+    pub fn get(&self, hash: &Hash) -> Option<Vec<u8>> {
+        self.value_iterator(hash).map(|i| i.flat_map(|v| v).collect())
+    }
+
+    pub fn data_size(&self, hash: &Hash) -> Option<u64> {
+        self.value_iterator(hash).map(|i| i.map(|v| v.len() as u64).sum())
+    }
+
+    pub fn exists(&self, hash: &Hash) -> bool {
+        self.value_iterator(hash).is_some()
+    }
+
+    pub fn len(&self) -> u64 {
+        self.blobs.len()
+    }
+
+    pub fn insert(&mut self, hash: Hash, value: Vec<u8>) {
+        for (index, chunk) in value.chunks(MAX_VALUE_SIZE).enumerate() {
+            let key = Key::new(hash, index as u32);
+
+            self.blobs.insert(key, chunk.to_vec()).unwrap();
+        }
+    }
+
+    pub fn remove(&mut self, hash: &Hash) -> bool {
+        let keys: Vec<Key> = self.blobs.range(hash.to_vec(), None).map(|(k, _)| k).collect();
+
+        if keys.is_empty() {
+            false
+        } else {
+            for key in keys {
+                self.blobs.remove(&key);
+            }
+            true
+        }
+    }
+
+    // Returns None if no value exists with the given hash, else provides an iterator over the
+    // value's chunks.
+    fn value_iterator(&self, hash: &Hash) -> Option<impl Iterator<Item = Vec<u8>> + '_> {
+        let mut iter = self.blobs.range(hash.to_vec(), None).map(|(_, v)| v);
+
+        let first = iter.next()?;
+
+        Some([first].into_iter().chain(iter))
+    }
+}
+
+fn init_blobs() -> StableBTreeMap<Memory, Key, Vec<u8>> {
+    let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
+    let memory = memory_manager.get(MemoryId::new(0));
+
+    StableBTreeMap::init(memory, size_of::<Key>() as u32, MAX_VALUE_SIZE as u32)
+}
+
+impl Default for StableBlobStorage {
+    fn default() -> Self {
+        StableBlobStorage { blobs: init_blobs() }
+    }
+}
+
+#[allow(dead_code)]
+#[repr(packed)]
+struct Key {
+    prefix: Hash,
+    chunk_index_bytes: [u8; 4],
+}
+
+impl Key {
+    fn new(prefix: Hash, chunk_index: u32) -> Key {
+        Key {
+            prefix,
+            chunk_index_bytes: chunk_index.to_be_bytes(),
+        }
+    }
+}
+
+impl Storable for Key {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = unsafe { std::slice::from_raw_parts((self as *const Key) as *const u8, size_of::<Key>()) };
+
+        Cow::from(bytes)
+    }
+
+    fn from_bytes(bytes: Vec<u8>) -> Self {
+        assert_eq!(bytes.len(), size_of::<Key>());
+
+        unsafe { std::ptr::read(bytes.as_ptr() as *const _) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn value_in_matches_value_out() {
+        let mut stable_storage = StableBlobStorage::default();
+
+        let hash = default_hash();
+
+        // We mod with a prime number so that each chunk of bytes is different, this validates that
+        // chunk ordering is preserved.
+        let value_in: Vec<_> = (0..10000).into_iter().map(|i| (i % 101) as u8).collect();
+
+        stable_storage.insert(hash, value_in.clone());
+
+        let value_out = stable_storage.get(&hash).unwrap();
+
+        assert_eq!(value_in, value_out)
+    }
+
+    // Checks that, for keys with matching prefixes, KeyA > KeyB <=> chunk_index A > chunk_index B
+    #[test]
+    fn key_ordering() {
+        let hash = default_hash();
+        let keys_as_bytes: Vec<_> = (0..1000).map(|i| Key::new(hash, i as u32).to_bytes().to_vec()).collect();
+
+        let mut keys_as_bytes_sorted = keys_as_bytes.clone();
+        keys_as_bytes_sorted.sort();
+
+        assert_eq!(keys_as_bytes, keys_as_bytes_sorted);
+    }
+
+    fn default_hash() -> Hash {
+        let vec: Vec<_> = (0..32).into_iter().collect();
+        Hash::try_from(vec).unwrap()
+    }
+}

--- a/backend/canisters/bucket/impl/src/model/stable_blob_storage.rs
+++ b/backend/canisters/bucket/impl/src/model/stable_blob_storage.rs
@@ -148,6 +148,12 @@ mod tests {
         assert_eq!(key.chunk_index_bytes, key_round_tripped.chunk_index_bytes);
     }
 
+    #[test]
+    fn key_size() {
+        // If the key size ever changes, old data won't be accessible
+        assert_eq!(size_of::<Key>(), 36);
+    }
+
     fn default_hash() -> Hash {
         let vec: Vec<_> = (0..32).into_iter().collect();
         Hash::try_from(vec).unwrap()

--- a/backend/canisters/bucket/impl/src/model/stable_blob_storage.rs
+++ b/backend/canisters/bucket/impl/src/model/stable_blob_storage.rs
@@ -137,6 +137,17 @@ mod tests {
         assert_eq!(keys_as_bytes, keys_as_bytes_sorted);
     }
 
+    #[test]
+    fn key_to_bytes_round_trip() {
+        let hash = default_hash();
+        let key = Key::new(hash, 123456789);
+
+        let key_round_tripped = Key::from_bytes(key.to_bytes().to_vec());
+
+        assert_eq!(key.prefix, key_round_tripped.prefix);
+        assert_eq!(key.chunk_index_bytes, key_round_tripped.chunk_index_bytes);
+    }
+
     fn default_hash() -> Hash {
         let vec: Vec<_> = (0..32).into_iter().collect();
         Hash::try_from(vec).unwrap()

--- a/backend/canisters/bucket/impl/src/queries/http_request.rs
+++ b/backend/canisters/bucket/impl/src/queries/http_request.rs
@@ -96,7 +96,7 @@ fn continue_streaming_file(token: Token, runtime_state: &RuntimeState) -> Stream
     }
 }
 
-fn chunk_bytes(blob_bytes: &ByteBuf, chunk_index: u32) -> (ByteBuf, bool) {
+fn chunk_bytes(mut blob_bytes: Vec<u8>, chunk_index: u32) -> (ByteBuf, bool) {
     let total_size = blob_bytes.len();
     let total_chunks = calc_chunk_count(BLOB_RESPONSE_CHUNK_SIZE_BYTES, total_size as u64);
     let last_chunk_index = total_chunks - 1;
@@ -109,7 +109,10 @@ fn chunk_bytes(blob_bytes: &ByteBuf, chunk_index: u32) -> (ByteBuf, bool) {
     let start = (BLOB_RESPONSE_CHUNK_SIZE_BYTES as usize) * (chunk_index as usize);
     let end = min(start + (BLOB_RESPONSE_CHUNK_SIZE_BYTES as usize), total_size);
 
-    (ByteBuf::from(&blob_bytes.as_slice()[start..end]), stream_next_chunk)
+    blob_bytes.drain(end..);
+    blob_bytes.drain(0..start);
+
+    (ByteBuf::from(blob_bytes), stream_next_chunk)
 }
 
 fn build_token(blob_id: u128, index: u32) -> Token {


### PR DESCRIPTION
This PR moves all of the blobs into stable memory.

This has 2 main advantages.
1 - This allows us to store far more data within each canister since stable memory is currently 32GB vs 4GB heap memory (and the stable memory limit is set to increase further).
2 - Upgrades will be much quicker and cheaper since we no longer need to copy this data to and from stable memory during upgrades.