### PR TITLE
Unarchive the buckets which were marked as full

### DIFF
--- a/backend/canisters/index/impl/src/lifecycle/post_upgrade.rs
+++ b/backend/canisters/index/impl/src/lifecycle/post_upgrade.rs
@@ -19,6 +19,7 @@ fn post_upgrade(args: Args) {
     let (mut data, log_messages, trace_messages): (Data, Vec<LogMessage>, Vec<LogMessage>) =
         serializer::deserialize(reader).unwrap();
 
+    data.buckets.unarchive_all();
     data.hydrate_blobs_owned();
 
     init_logger(data.test_mode);

--- a/backend/canisters/index/impl/src/model/buckets.rs
+++ b/backend/canisters/index/impl/src/model/buckets.rs
@@ -17,6 +17,13 @@ pub struct Buckets {
 }
 
 impl Buckets {
+    // Now that we are storing blobs in stable memory the buckets can each hold far more data
+    pub fn unarchive_all(&mut self) {
+        for (_, b) in self.full_buckets.drain() {
+            self.active_buckets.push(b);
+        }
+    }
+
     pub fn get(&self, canister_id: &CanisterId) -> Option<&BucketRecord> {
         self.active_buckets
             .iter()


### PR DESCRIPTION
The limit was 1GB but now its 8GB so we can unarchive the buckets that were previously marked as full.